### PR TITLE
Extract 'glassfish' username to be a configurable ansible variable

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,6 +1,7 @@
 ---
 
-# Payara directory, domain and admin user's password
+# Payara user, directory, domain and admin user's password
+payara_user: 'glassfish'
 payara_directory: 'payara41'
 payara_domain: 'domain1'
 payara_admin_password: '{{ vault_payara_admin_password }}'

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,9 +1,7 @@
 ---
 
-# Payara user, directory, domain and admin user's password
+# Payara user and admin user's password
 payara_user: 'glassfish'
-payara_directory: 'payara41'
-payara_domain: 'domain1'
 payara_admin_password: '{{ vault_payara_admin_password }}'
 
 # Database root user's username and password

--- a/roles/authn-simple/handlers/authn-simple-handler.yml
+++ b/roles/authn-simple/handlers/authn-simple-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install authn-simple'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/authn.simple; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/authn.simple; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/authn-simple/tasks/main.yml
+++ b/roles/authn-simple/tasks/main.yml
@@ -2,38 +2,38 @@
 
 - name: 'Check authn-simple package'
   stat:
-    path: /home/glassfish/downloads/authn.simple-2.0.0-distro.zip
+    path: /home/{{ payara_user }}/downloads/authn.simple-2.0.0-distro.zip
   register: packageResult
 
 - name: 'Download authn-simple'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/authn.simple/2.0.0/authn.simple-2.0.0-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check authn-simple installation'
   stat:
-    path: /home/glassfish/install/authn.simple
+    path: /home/{{ payara_user }}/install/authn.simple
   register: installationResult
 
 - name: 'Unarchive authn-simple if not installed'
   unarchive:
-    src: /home/glassfish/downloads/authn.simple-2.0.0-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/authn.simple-2.0.0-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Configure authn-simple setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/install/authn.simple/setup.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/authn.simple/setup.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - authn-simple-handler
@@ -41,9 +41,9 @@
 - name: 'Configure authn-simple run.properties'
   template:
     src: templates/run.properties.j2
-    dest: /home/glassfish/install/authn.simple/run.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/authn.simple/run.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - authn-simple-handler
@@ -51,9 +51,9 @@
 - name: 'Configure authn-simple logback.xml'
   copy:
     src: files/logback.xml
-    dest: /home/glassfish/install/authn.simple/logback.xml
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/authn.simple/logback.xml
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - authn-simple-handler

--- a/roles/icat-lucene/handlers/icat-lucene-handler.yml
+++ b/roles/icat-lucene/handlers/icat-lucene-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install icat-lucene'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/icat.lucene; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/icat.lucene; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/icat-lucene/tasks/main.yml
+++ b/roles/icat-lucene/tasks/main.yml
@@ -2,38 +2,38 @@
 
 - name: 'Check icat-lucene package'
   stat:
-    path: /home/glassfish/downloads/icat.lucene-1.1.0-distro.zip
+    path: /home/{{ payara_user }}/downloads/icat.lucene-1.1.0-distro.zip
   register: packageResult
 
 - name: 'Download icat-lucene'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/icat.lucene/1.1.0/icat.lucene-1.1.0-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check icat-lucene installation'
   stat:
-    path: /home/glassfish/install/icat.lucene
+    path: /home/{{ payara_user }}/install/icat.lucene
   register: installationResult
 
 - name: 'Unarchive icat-lucene if not installed'
   unarchive:
-    src: /home/glassfish/downloads/icat.lucene-1.1.0-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/icat.lucene-1.1.0-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Configure icat-lucene setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/install/icat.lucene/setup.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/icat.lucene/setup.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - icat-lucene-handler
@@ -41,27 +41,27 @@
 - name: 'Configure icat-lucene run.properties'
   template:
     src: templates/run.properties.j2
-    dest: /home/glassfish/install/icat.lucene/run.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/icat.lucene/run.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - icat-lucene-handler
 
 - name: 'Create icat-lucene data directory'
   file:
-    path: /home/glassfish/data/lucene
+    path: /home/{{ payara_user }}/data/lucene
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Configure icat-lucene logback.xml'
   copy:
     src: files/logback.xml
-    dest: /home/glassfish/install/icat.lucene/logback.xml
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/icat.lucene/logback.xml
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - icat-lucene-handler

--- a/roles/icat-lucene/templates/run.properties.j2
+++ b/roles/icat-lucene/templates/run.properties.j2
@@ -1,6 +1,6 @@
 # Real comments in this file are marked with '#' whereas commented out lines
 # are marked with '!'
 
-directory = /home/glassfish/data/lucene
+directory = /home/{{ payara_user }}/data/lucene
 commitSeconds = 5
 ip = 127.0.0.1/32 0:0:0:0:0:0:0:1/128 10.0.0.1/8 {{ ansible_default_ipv4.address }}/32

--- a/roles/icat-server/handlers/icat-server-handler.yml
+++ b/roles/icat-server/handlers/icat-server-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install icat-server'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/icat.server; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/icat.server; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/icat-server/tasks/main.yml
+++ b/roles/icat-server/tasks/main.yml
@@ -20,101 +20,101 @@
   - libmysql-java
   when: ansible_os_family == 'Debian'
 
-- name: 'Check glassfish domain'
+- name: 'Check payara domain'
   stat:
-    path: /home/glassfish/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext
   register: domainResult
 
 - name: 'Create symlink to mysql connector library'
   file:
     src: /usr/share/java/mysql-connector-java.jar
-    path: /home/glassfish/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
+    path: /home/{{ payara_user }}/{{ payara_directory }}/glassfish/domains/{{ payara_domain }}/lib/ext/mysql-connector-java.jar
     state: link
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: domainResult.stat.exists is defined and domainResult.stat.exists == true
   notify: payara-handler
 
 - name: 'Check icat-server package'
   stat:
-    path: /home/glassfish/downloads/icat.server-4.9.1-distro.zip
+    path: /home/{{ payara_user }}/downloads/icat.server-4.9.1-distro.zip
   register: packageResult
 
 - name: 'Download icat-server'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/icat.server/4.9.1/icat.server-4.9.1-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check icat-server installation'
   stat:
-    path: /home/glassfish/install/icat.server
+    path: /home/{{ payara_user }}/install/icat.server
   register: installationResult
 
 - name: 'Unarchive icat-server if not installed'
   unarchive:
-    src: /home/glassfish/downloads/icat.server-4.9.1-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/icat.server-4.9.1-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
-- name: 'Create bin directory for the glassfish user'
+- name: 'Create bin directory for the payara user'
   file:
-    path: /home/glassfish/bin
+    path: /home/{{ payara_user }}/bin
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
-- name: 'Add path to glassfish bin directory for icat-server to PATH variable'
+- name: 'Add path to payara user bin directory for icat-server to PATH variable'
   lineinfile:
-    path: /home/glassfish/.bashrc
-    line: 'export PATH=$PATH:/home/glassfish/bin'
+    path: /home/{{ payara_user }}/.bashrc
+    line: 'export PATH=$PATH:/home/{{ payara_user }}/bin'
 
 - name: 'Create a stash directory for assembling configurations'
   file:
-    path: /home/glassfish/stash
+    path: /home/{{ payara_user }}/stash
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create a stash directory for icat-server configs'
   file:
-    path: /home/glassfish/stash/icat-server
+    path: /home/{{ payara_user }}/stash/icat-server
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
-- name: 'Copy over glassfish setup.properties'
+- name: 'Copy over payara setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/stash/icat-server/1-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/icat-server/1-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Copy over icat-server setup.properties'
   template:
     src: templates/setup.properties.j2
-    dest: /home/glassfish/stash/icat-server/2-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/icat-server/2-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Configure icat-server setup.properties by concatenation of files in the stash'
   assemble:
-    src: /home/glassfish/stash/icat-server
-    dest: /home/glassfish/install/icat.server/setup.properties
+    src: /home/{{ payara_user }}/stash/icat-server
+    dest: /home/{{ payara_user }}/install/icat.server/setup.properties
     delimiter: '\n'
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - icat-server-handler
@@ -122,9 +122,9 @@
 - name: 'Configure icat-server run.properties'
   template:
     src: templates/run.properties.j2
-    dest: /home/glassfish/install/icat.server/run.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/icat.server/run.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - icat-server-handler
@@ -132,9 +132,9 @@
 - name: 'Configure icat-server logback.xml'
   copy:
     src: files/logback.xml
-    dest: /home/glassfish/install/icat.server/logback.xml
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/icat.server/logback.xml
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - icat-server-handler

--- a/roles/icat-server/templates/run.properties.j2
+++ b/roles/icat-server/templates/run.properties.j2
@@ -46,7 +46,7 @@ log.list = SESSION WRITE READ INFO
 # Lucene
 lucene.url = https://{{ lucene_url }}:8181
 lucene.populateBlockSize = 1000
-lucene.directory = /home/glassfish/data/lucene
+lucene.directory = /home/{{ payara_user }}/data/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 5
 lucene.entitiesToIndex = Dataset Investigation InvestigationUser DatasetParameter InvestigationParameter Sample

--- a/roles/ids-server/handlers/ids-server-handler.yml
+++ b/roles/ids-server/handlers/ids-server-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install ids-server'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/ids.server; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/ids.server; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/ids-server/tasks/main.yml
+++ b/roles/ids-server/tasks/main.yml
@@ -2,95 +2,95 @@
 
 - name: 'Check ids-server package'
   stat:
-    path: /home/glassfish/downloads/ids.server-1.9.0-distro.zip
+    path: /home/{{ payara_user }}/downloads/ids.server-1.9.0-distro.zip
   register: packageResult
 
 - name: 'Download ids-server'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/ids.server/1.9.0/ids.server-1.9.0-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check ids-server installation'
   stat:
-    path: /home/glassfish/install/ids.server
+    path: /home/{{ payara_user }}/install/ids.server
   register: installationResult
 
 - name: 'Unarchive ids-server if not installed'
   unarchive:
-    src: /home/glassfish/downloads/ids.server-1.9.0-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/ids.server-1.9.0-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Create main data directory'
   file:
-    path: /home/glassfish/data/main
+    path: /home/{{ payara_user }}/data/main
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create archive data directory'
   file:
-    path: /home/glassfish/data/archive
+    path: /home/{{ payara_user }}/data/archive
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create cache data directory'
   file:
-    path: /home/glassfish/data/cache
+    path: /home/{{ payara_user }}/data/cache
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create a stash directory for assembling configurations'
   file:
-    path: /home/glassfish/stash
+    path: /home/{{ payara_user }}/stash
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create a stash directory for ids-server configs'
   file:
-    path: /home/glassfish/stash/ids-server
+    path: /home/{{ payara_user }}/stash/ids-server
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
-- name: 'Copy over glassfish setup.properties'
+- name: 'Copy over {{ payara_user }} setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/stash/ids-server/1-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/ids-server/1-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Copy over ids-server setup.properties'
   copy:
     src: files/setup.properties
-    dest: /home/glassfish/stash/ids-server/2-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/ids-server/2-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Configure ids-server setup.properties by concatenation of files in the stash'
   assemble:
-    src: /home/glassfish/stash/ids-server
-    dest: /home/glassfish/install/ids.server/setup.properties
+    src: /home/{{ payara_user }}/stash/ids-server
+    dest: /home/{{ payara_user }}/install/ids.server/setup.properties
     delimiter: '\n'
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - ids-server-handler
@@ -98,9 +98,9 @@
 - name: 'Configure ids-server run.properties'
   template:
     src: templates/run.properties.j2
-    dest: /home/glassfish/install/ids.server/run.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/ids.server/run.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - ids-server-handler
@@ -108,9 +108,9 @@
 - name: 'Configure ids-server logback.xml'
   copy:
     src: files/logback.xml
-    dest: /home/glassfish/install/ids.server/logback.xml
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/ids.server/logback.xml
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - ids-server-handler

--- a/roles/ids-server/templates/run.properties.j2
+++ b/roles/ids-server/templates/run.properties.j2
@@ -4,9 +4,9 @@ icat.url = https://{{ icat_url }}:8181
 plugin.zipMapper.class = org.icatproject.ids.storage.ZipMapper
 
 plugin.main.class = org.icatproject.ids.storage.MainFileStorage
-plugin.main.dir = /home/glassfish/data/main
+plugin.main.dir = /home/{{ payara_user }}/data/main
 
-cache.dir = /home/glassfish/data/cache
+cache.dir = /home/{{ payara_user }}/data/cache
 preparedCount = 10000
 processQueueIntervalSeconds = 5
 rootUserNames = simple/root
@@ -17,7 +17,7 @@ maxIdsInQuery = 1000
 
 # Properties for archive storage
 plugin.archive.class = org.icatproject.ids.storage.ArchiveFileStorage
-plugin.archive.dir = /home/glassfish/data/archive
+plugin.archive.dir = /home/{{ payara_user }}/data/archive
 writeDelaySeconds = 60
 startArchivingLevel1024bytes = 5000000
 stopArchivingLevel1024bytes =  4000000
@@ -27,8 +27,8 @@ tidyBlockSize = 500
 # File checking properties
 filesCheck.parallelCount = 5
 filesCheck.gapSeconds = 5
-filesCheck.lastIdFile = /home/glassfish/logs/lastIdFile
-filesCheck.errorLog = /home/glassfish/logs/filesCheckErrors.log
+filesCheck.lastIdFile = /home/{{ payara_user }}/logs/lastIdFile
+filesCheck.errorLog = /home/{{ payara_user }}/logs/filesCheckErrors.log
 
 # Link properties
 linkLifetimeSeconds = 3600

--- a/roles/ids-storage_file/handlers/ids-storage_file-handler.yml
+++ b/roles/ids-storage_file/handlers/ids-storage_file-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install ids-storage_file'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/ids.storage_file; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/ids.storage_file; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/ids-storage_file/tasks/main.yml
+++ b/roles/ids-storage_file/tasks/main.yml
@@ -2,38 +2,38 @@
 
 - name: 'Check ids-storage_file package'
   stat:
-    path: /home/glassfish/downloads/ids.storage_file-1.4.1-distro.zip
+    path: /home/{{ payara_user }}/downloads/ids.storage_file-1.4.1-distro.zip
   register: packageResult
 
 - name: 'Download ids-storage_file'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/ids.storage_file/1.4.1/ids.storage_file-1.4.1-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check ids-storage_file installation'
   stat:
-    path: /home/glassfish/install/ids.storage_file
+    path: /home/{{ payara_user }}/install/ids.storage_file
   register: installationResult
 
 - name: 'Unarchive ids-storage_file if not installed'
   unarchive:
-    src: /home/glassfish/downloads/ids.storage_file-1.4.1-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/ids.storage_file-1.4.1-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Configure ids-storage_file setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/install/ids.storage_file/setup.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/ids.storage_file/setup.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - ids-storage_file-handler

--- a/roles/payara/tasks/check-payara.yml
+++ b/roles/payara/tasks/check-payara.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: 'Check payara is running'
-  shell: 'su -l glassfish -c "asadmin list-applications"'
+  shell: 'su -l {{ payara_user }} -c "asadmin list-applications"'
   register: payaraStatus
   become: true
   become_user: root

--- a/roles/payara/tasks/installation.yml
+++ b/roles/payara/tasks/installation.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: 'Setup payara'
-  shell: 'su -l glassfish -c "python scripts/setup-glassfish.py {{ payara_domain }} 75% {{ payara_admin_password }}"'
+  shell: 'su -l {{ payara_user }} -c "python scripts/setup-glassfish.py {{ payara_domain }} 75% {{ payara_admin_password }}"'
   become: true
   become_user: root
   args:

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -1,39 +1,39 @@
 ---
 
-- name: 'Create glassfish group'
+- name: 'Create payara user group'
   group:
-    name: glassfish
+    name: '{{ payara_user }}'
     state: present
 
-- name: 'Create glassfish user'
+- name: 'Create payara user'
   user:
-    name: glassfish
+    name: '{{ payara_user }}'
     createhome: true
-    group: glassfish
+    group: '{{ payara_user }}'
     shell: /bin/bash
 
 - name: 'Create downloads directory'
   file:
-    path: /home/glassfish/downloads
+    path: /home/{{ payara_user }}/downloads
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create install directory'
   file:
-    path: /home/glassfish/install
+    path: /home/{{ payara_user }}/install
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create scripts directory'
   file:
-    path: /home/glassfish/scripts
+    path: /home/{{ payara_user }}/scripts
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Install payara init script'
@@ -46,49 +46,49 @@
 
 - name: 'Add path to payara executable to PATH variable'
   lineinfile:
-    path: /home/glassfish/.bashrc
+    path: /home/{{ payara_user }}/.bashrc
     line: 'export PATH=$HOME/{{ payara_directory }}/bin:$PATH'
 
 - name: 'Check payara package'
   stat:
-    path: /home/glassfish/downloads/payara-4.1.2.181.zip
+    path: /home/{{ payara_user }}/downloads/payara-4.1.2.181.zip
   register: packageResult
 
 - name: 'Download payara'
   get_url:
     url: http://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/4.1.2.181/payara-4.1.2.181.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check payara setup script'
   stat:
-    path: /home/glassfish/scripts/setup-glassfish.py
+    path: /home/{{ payara_user }}/scripts/setup-glassfish.py
   register: scriptResult
 
 - name: 'Download payara setup script'
   get_url:
     url: https://icatproject.org/misc/scripts/setup-glassfish.py
-    dest: /home/glassfish/scripts
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/scripts
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: scriptResult.stat.exists is defined and scriptResult.stat.exists == false
 
 - name: 'Check payara installation'
   stat:
-    path: /home/glassfish/{{ payara_directory }}
+    path: /home/{{ payara_user }}/{{ payara_directory }}
   register: installationResult
 
 - name: 'Unarchive payara if not installed'
   unarchive:
-    src: /home/glassfish/downloads/payara-4.1.2.181.zip
-    dest: /home/glassfish
+    src: /home/{{ payara_user }}/downloads/payara-4.1.2.181.zip
+    dest: /home/{{ payara_user }}
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Setup payara if not setup'

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -115,7 +115,7 @@
 - name: 'Unarchive payara if not installed'
   unarchive:
     src: /home/{{ payara_user }}/downloads/payara-{{ payara_version }}.zip
-    dest: /home/{{ payara_user }}
+    dest: /home/{{ payara_user }}/unpackage
     remote_src: true
     owner: '{{ payara_user }}'
     group: '{{ payara_user }}'

--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -38,10 +38,10 @@
 
 - name: 'Create unpackage directory'
   file:
-    path: /home/glassfish/unpackage
+    path: /home/{{ payara_user }}/unpackage
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Install payara init script'
@@ -54,7 +54,7 @@
      
 - name: 'Check if .bash_profile exists'
   stat:
-    path: /home/glassfish/.bash_profile
+    path: /home/{{ payara_user }}/.bash_profile
   register: bashProfileResult
 
 - name: 'Add path to payara executable to PATH variable in .bash_profile'
@@ -66,7 +66,7 @@
 
 - name: 'Add path to payara executable to PATH variable in .profile'
   lineinfile:
-    path: /home/glassfish/.profile
+    path: /home/{{ payara_user }}/.profile
     line: 'export PATH=$HOME/{{ payara_directory }}/bin:$PATH'
     regexp: '^export PATH=\$HOME\/payara[0-9]+(\.{1}[0-9]+)*\/bin:\$PATH$'
   when: bashProfileResult.stat.exists is defined and bashProfileResult.stat.exists == false
@@ -104,8 +104,8 @@
     path: /home/{{ payara_user }}/{{ payara_directory }}
   register: installationResult
 
-- name: 'Delete contents of /home/glassfish/unpackage'
-  shell: 'su -l glassfish -c "rm -rf /home/glassfish/unpackage/*"'
+- name: 'Delete contents of /home/{{ payara_user }}/unpackage'
+  shell: 'su -l {{ payara_user }} -c "rm -rf /home/{{ payara_user }}/unpackage/*"'
   become: true
   become_user: root
   args:
@@ -121,8 +121,8 @@
     group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
-- name: 'Move contents of /home/glassfish/unpackage'
-  shell: 'su -l glassfish -c "mv /home/glassfish/unpackage/payara* /home/glassfish/payara{{ payara_version }}"'
+- name: 'Move contents of /home/{{ payara_user }}/unpackage'
+  shell: 'su -l {{ payara_user }} -c "mv /home/{{ payara_user }}/unpackage/payara* /home/{{ payara_user }}/payara{{ payara_version }}"'
   become: true
   become_user: root
   args:

--- a/roles/payara/templates/payara-init.j2
+++ b/roles/payara/templates/payara-init.j2
@@ -10,7 +10,7 @@
 # Description: Start the Glassfish J2EE Server
 ### END INIT INFO
 # customize values for your needs
-NAME=glassfish
+NAME="{{ payara_user }}"
 GLASSFISH_USER=$NAME
 GLASSFISH_DIR="/home/$NAME/{{ payara_directory }}"
 ASADMIN="$GLASSFISH_DIR/glassfish/bin/asadmin"

--- a/roles/payara/templates/setup.properties.j2
+++ b/roles/payara/templates/setup.properties.j2
@@ -1,7 +1,7 @@
 # Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/{{ payara_directory }}
+home = /home/{{ payara_user }}/{{ payara_directory }}
 port = 4848
 
 # WildFly

--- a/roles/topcat/handlers/topcat-handler.yml
+++ b/roles/topcat/handlers/topcat-handler.yml
@@ -4,7 +4,7 @@
   import_tasks: roles/payara/tasks/check-payara.yml
 
 - name: 'Re-install topcat'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/topcat; ./setup -vv install"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; ./setup -vv install"'
   become: true
   become_user: root
   args:

--- a/roles/topcat/tasks/create-topcat-json.yml
+++ b/roles/topcat/tasks/create-topcat-json.yml
@@ -1,63 +1,63 @@
 ---
 
 - name: 'Create topcat.json part 1'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat.json.example | jq '.site.topcatUrl = \"https://{{ topcat_url }}:8181\"' > topcat-intermediate1.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat.json.example | jq '.site.topcatUrl = \"https://{{ topcat_url }}:8181\"' > topcat-intermediate1.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 2'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate1.json | jq '.facilities[0].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat-intermediate2.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate1.json | jq '.facilities[0].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat-intermediate2.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 3'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate2.json | jq '.facilities[0].icatUrl = \"https://{{ icat_url }}:8181\"' > topcat-intermediate3.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate2.json | jq '.facilities[0].icatUrl = \"https://{{ icat_url }}:8181\"' > topcat-intermediate3.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 4'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate3.json | jq 'del(.facilities[0].authenticationTypes[1])' > topcat-intermediate4.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate3.json | jq 'del(.facilities[0].authenticationTypes[1])' > topcat-intermediate4.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 5'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate4.json | jq '.facilities[0].downloadTransportTypes[0].type = \"http\"' > topcat-intermediate5.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate4.json | jq '.facilities[0].downloadTransportTypes[0].type = \"http\"' > topcat-intermediate5.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 6'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate5.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = \"http://{{ ids_url }}:8080\"' > topcat-intermediate6.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate5.json | jq '.facilities[0].downloadTransportTypes[0].idsUrl = \"http://{{ ids_url }}:8080\"' > topcat-intermediate6.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 7'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate6.json | jq '.facilities[0].downloadTransportTypes[1].type = \"https\"' > topcat-intermediate7.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate6.json | jq '.facilities[0].downloadTransportTypes[1].type = \"https\"' > topcat-intermediate7.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Create topcat.json part 8'
-  shell: su -l glassfish -c "cd /home/glassfish/install/topcat; cat topcat-intermediate7.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat.json"
+  shell: su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cat topcat-intermediate7.json | jq '.facilities[0].downloadTransportTypes[1].idsUrl = \"https://{{ ids_url }}:8181\"' > topcat.json"
   become: true
   become_user: root
   args:
     executable: /bin/bash
 
 - name: 'Remove intermediate files'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/topcat; rm topcat-intermediate*"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; rm topcat-intermediate*"'
   become: true
   become_user: root
   args:
@@ -65,5 +65,5 @@
 
 - name: 'Set mode of topcat.json'
   file:
-    path: /home/glassfish/install/topcat/topcat.json
+    path: /home/{{ payara_user }}/install/topcat/topcat.json
     mode: 0664

--- a/roles/topcat/tasks/main.yml
+++ b/roles/topcat/tasks/main.yml
@@ -7,30 +7,30 @@
 
 - name: 'Check topcat package'
   stat:
-    path: /home/glassfish/downloads/topcat-2.4.0-distro.zip
+    path: /home/{{ payara_user }}/downloads/topcat-2.4.0-distro.zip
   register: packageResult
 
 - name: 'Download topcat'
   get_url:
     url: https://repo.icatproject.org/repo/org/icatproject/topcat/2.4.0/topcat-2.4.0-distro.zip
-    dest: /home/glassfish/downloads
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/downloads
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   when: packageResult.stat.exists is defined and packageResult.stat.exists == false
 
 - name: 'Check topcat installation'
   stat:
-    path: /home/glassfish/install/topcat
+    path: /home/{{ payara_user }}/install/topcat
   register: installationResult
 
 - name: 'Unarchive topcat if not installed'
   unarchive:
-    src: /home/glassfish/downloads/topcat-2.4.0-distro.zip
-    dest: /home/glassfish/install
+    src: /home/{{ payara_user }}/downloads/topcat-2.4.0-distro.zip
+    dest: /home/{{ payara_user }}/install
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
   when: installationResult.stat.exists is defined and installationResult.stat.exists == false
 
 - name: 'Create database for topcat'
@@ -49,43 +49,43 @@
 
 - name: 'Create a stash directory for assembling configurations'
   file:
-    path: /home/glassfish/stash
+    path: /home/{{ payara_user }}/stash
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
 - name: 'Create a stash directory for topcat configs'
   file:
-    path: /home/glassfish/stash/topcat
+    path: /home/{{ payara_user }}/stash/topcat
     state: directory
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0775
 
-- name: 'Copy over glassfish setup.properties'
+- name: 'Copy over {{ payara_user }} setup.properties'
   template:
     src: roles/payara/templates/setup.properties.j2
-    dest: /home/glassfish/stash/topcat/1-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/topcat/1-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Copy over topcat-setup.properties'
   template:
     src: templates/topcat-setup.properties.j2
-    dest: /home/glassfish/stash/topcat/2-part
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/stash/topcat/2-part
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
 
 - name: 'Configure topcat-setup.properties by concatenation of files in the stash'
   assemble:
-    src: /home/glassfish/stash/topcat
-    dest: /home/glassfish/install/topcat/topcat-setup.properties
+    src: /home/{{ payara_user }}/stash/topcat
+    dest: /home/{{ payara_user }}/install/topcat/topcat-setup.properties
     delimiter: '\n'
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - topcat-handler
@@ -93,16 +93,16 @@
 - name: 'Configure topcat.properties'
   template:
     src: templates/topcat.properties.j2
-    dest: /home/glassfish/install/topcat/topcat.properties
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/topcat/topcat.properties
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0600
   notify:
   - topcat-handler
 
 - name: 'Check topcat.json'
   stat:
-    path: /home/glassfish/install/topcat/topcat.json
+    path: /home/{{ payara_user }}/install/topcat/topcat.json
   register: topcatJsonResult
 
 - name: 'Create topcat.json'
@@ -113,33 +113,33 @@
 
 - name: 'Configure lang.json'
   copy:
-    src: /home/glassfish/install/topcat/lang.json.example
-    dest: /home/glassfish/install/topcat/lang.json
+    src: /home/{{ payara_user }}/install/topcat/lang.json.example
+    dest: /home/{{ payara_user }}/install/topcat/lang.json
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - topcat-handler
 
 - name: 'Configure topcat.css'
   copy:
-    src: /home/glassfish/install/topcat/topcat.css.example
-    dest: /home/glassfish/install/topcat/topcat.css
+    src: /home/{{ payara_user }}/install/topcat/topcat.css.example
+    dest: /home/{{ payara_user }}/install/topcat/topcat.css
     remote_src: true
-    owner: glassfish
-    group: glassfish
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - topcat-handler
 
 - name: 'Check content directory'
   stat:
-    path: /home/glassfish/install/topcat/content
+    path: /home/{{ payara_user }}/install/topcat/content
   register: contentResult
 
 - name: 'Configure content directory'
-  shell: 'su -l glassfish -c "cd /home/glassfish/install/topcat; cp -r content.example content"'
+  shell: 'su -l {{ payara_user }} -c "cd /home/{{ payara_user }}/install/topcat; cp -r content.example content"'
   become: true
   become_user: root
   args:
@@ -151,9 +151,9 @@
 - name: 'Configure topcat logback.xml'
   copy:
     src: files/logback.xml
-    dest: /home/glassfish/install/topcat/logback.xml
-    owner: glassfish
-    group: glassfish
+    dest: /home/{{ payara_user }}/install/topcat/logback.xml
+    owner: '{{ payara_user }}'
+    group: '{{ payara_user }}'
     mode: 0664
   notify:
   - topcat-handler


### PR DESCRIPTION
In getting TravisCI set up, I was coming across a lot of problems with the fact that only the `glassfish` user could perform certain tasks and it was difficult to configure TravisCI to work around this. With this change, we would be able to set the `payara_user` variable to be `travis` (the user TravisCI uses to build in its VMs) and thus the travis user would have access to all the same stuff the `glassfish` user normally does.